### PR TITLE
Fix the access to the admin area of the app.

### DIFF
--- a/iou/apps.py
+++ b/iou/apps.py
@@ -1,5 +1,5 @@
 from django.apps import AppConfig
-from django.urls import reverse
+from django.urls import reverse_lazy
 
 
 class IouConfig(AppConfig):
@@ -9,4 +9,4 @@ class IouConfig(AppConfig):
     def ready(self):
         from django.conf import settings
 
-        settings.LOGIN_URL = reverse("login")
+        settings.LOGIN_URL = reverse_lazy("login")


### PR DESCRIPTION
The app showed an error when trying to access http://localhost:8000/admin/iou/:

```
Page not found (404)
Request Method:	GET
Request URL:	http://localhost:8000/admin/iou/
Raised by:	django.contrib.admin.sites.catch_all_view
Using the URLconf defined in iouproject.urls, Django tried these URL patterns, in this order:

iou/
admin/ [name='index']
admin/ login/ [name='login']
admin/ logout/ [name='logout']
admin/ password_change/ [name='password_change']
admin/ password_change/done/ [name='password_change_done']
admin/ autocomplete/ [name='autocomplete']
admin/ jsi18n/ [name='jsi18n']
admin/ r/<int:content_type_id>/<path:object_id>/ [name='view_on_site']
admin/ (?P<url>.*)$
The current path, admin/iou/, matched the last one.
```

To avoid this, use [reverse_lazy](https://docs.djangoproject.com/en/5.0/ref/urlresolvers/#reverse-lazy) instead of [reverse](https://docs.djangoproject.com/en/5.0/ref/urlresolvers/#reverse), to resolve the login url.