### PR TITLE
Support configuration for being run behind a reverse proxy

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+# https://coverage.readthedocs.io/en/latest/source.html#source
+[run]
+omit=**/tests/**
+  iouproject/asgi.py
+  iouproject/wsgi.py

--- a/.env.template
+++ b/.env.template
@@ -10,3 +10,7 @@ CURRENCY_CODE=EUR
 SESSION_COOKIE_AGE=1209600
 SLACK_WEBHOOK=https://hooks.slack.com/services/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ADMIN_USER=admin
+
+# Set the following if the application runs under a reverse proxy like nginx,
+# with the path prefix configured by the reverse proxy.
+#PROXY_PREFIX=/iou

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Copy the `.env.template` from this project to a file `.env`, and adjust any para
 
 * The `SECRET_KEY` can be generated using the [get_random_secret_key](https://github.com/django/django/blob/5.0b1/django/core/management/utils.py#L79:L84) function in Django.
 * Set `DEBUG` to `false` for a production environment.
+* If the application runs behind a reverse proxy like nginx or apache, set `PROXY_PREFIX` to the url path prefix clients provide to access the application.
 
 ### Run the docker image
 

--- a/iou/apps.py
+++ b/iou/apps.py
@@ -11,4 +11,4 @@ class IouConfig(AppConfig):
 
         import iou.audit.signals  # noqa: F401
 
-        settings.LOGIN_URL = reverse_lazy("login")
+        settings.LOGIN_URL = reverse_lazy("iou:login")

--- a/iou/templates/iou/index.html
+++ b/iou/templates/iou/index.html
@@ -34,9 +34,9 @@
   </div>
 </dialog>
 {% include "iou/partials/debt_list.html" %}
-<form action="{% url 'logout' %}" method="post">
+<form action="{% url 'iou:logout' %}" method="post">
   {% csrf_token %}
-  <input type="hidden" name="next" value="{%url 'login' %}">
+  <input type="hidden" name="next" value="{%url 'iou:login' %}">
   <button class="button--logout" type="submit">{% translate "Log out" %}</button>
 </form>
 {% endblock%}

--- a/iou/templates/iou/partials/amount_form.html
+++ b/iou/templates/iou/partials/amount_form.html
@@ -1,7 +1,7 @@
 <form
   id="amount-form"
   class="amount-form"
-  hx-post="{% url 'index' %}"
+  hx-post="{% url 'iou:index' %}"
   hx-target="#debts"
   hx-swap="outerHTML"
   hx-swap-oob="true"

--- a/iou/templates/iou/partials/debt_list.html
+++ b/iou/templates/iou/partials/debt_list.html
@@ -11,7 +11,7 @@
       {% blocktranslate asvar message_delete_confirm with debt_text=debt_text%}Delete {{ debt_text }}?{% endblocktranslate %}
       <form
         class="debt-list-form"
-        hx-post="{%url 'delete' latest_debt.id %}"
+        hx-post="{%url 'iou:delete' latest_debt.id %}"
         hx-target="#debts"
         hx-swap="outerHTML"
         hx-indicator="#spinner"

--- a/iou/templates/registration/login.html
+++ b/iou/templates/registration/login.html
@@ -5,7 +5,7 @@
 <form method="post">
     {% csrf_token %}
     {{ form }}
-    <input type="hidden" name="next" value="{%url 'index' %}">
+    <input type="hidden" name="next" value="{%url 'iou:index' %}">
     <button type="submit">{% translate "Log in" %}</button>
 </form>
 {%endblock%}

--- a/iou/tests/test_delete_debt.py
+++ b/iou/tests/test_delete_debt.py
@@ -29,7 +29,7 @@ def test_delete_debt_success(
     # Don't care about Slack messages sent during test fixture setup.
     mock_slack_request.request.reset()
 
-    response = client.post(reverse("delete", kwargs={"debt_id": 2}))
+    response = client.post(reverse("iou:delete", kwargs={"debt_id": 2}))
 
     assert response.status_code == 200
     assert response.context.template_name == "iou/partials/debt_list.html"
@@ -67,7 +67,7 @@ def test_delete_unknown_debt_fail(
     # Don't care about Slack messages sent during test fixture setup.
     mock_slack_request.request.reset()
 
-    response = client.post(reverse("delete", kwargs={"debt_id": 3}))
+    response = client.post(reverse("iou:delete", kwargs={"debt_id": 3}))
 
     assert response.status_code == 404
 

--- a/iou/tests/test_form_submission.py
+++ b/iou/tests/test_form_submission.py
@@ -89,7 +89,7 @@ def test_add_debt(
     debts = Debt.objects.all()
     assert debts.count() == 0
 
-    response = client.post(reverse("index"), client_input)
+    response = client.post(reverse("iou:index"), client_input)
 
     assert response.status_code == 200
     assert response.context[0].template_name == "iou/partials/amount_form.html"
@@ -195,7 +195,7 @@ def test_invalid_input(
     debts = Debt.objects.all()
     assert debts.count() == 0
 
-    response = client.post(reverse("index"), client_input)
+    response = client.post(reverse("iou:index"), client_input)
 
     assert response.status_code == 400
     response_json: dict = response.json()

--- a/iou/tests/test_response_context.py
+++ b/iou/tests/test_response_context.py
@@ -26,7 +26,7 @@ def test_list_debts(
     debt_factory(debtor=Person.PERSON_1, amount=5.0)
     debt_factory(debtor=Person.PERSON_2, amount=7.5, description=None)
 
-    response = client.get(reverse("index"))
+    response = client.get(reverse("iou:index"))
     assert response.status_code == 200
     latest_debts: Iterable[Debt] = response.context["latest_debts"]
 
@@ -59,7 +59,7 @@ def test_no_debts(
     Then the list of debts is empty
     And the net debt is None.
     """
-    response = client.get(reverse("index"))
+    response = client.get(reverse("iou:index"))
     assert response.status_code == 200
     latest_debts: Iterable[Debt] = response.context["latest_debts"]
     assert len(latest_debts) == 0
@@ -84,7 +84,7 @@ def test_net_debt_zero(
     debt_factory(debtor=Person.PERSON_1, amount=5.0)
     debt_factory(debtor=Person.PERSON_2, amount=9.33, description=None)
 
-    response = client.get(reverse("index"))
+    response = client.get(reverse("iou:index"))
     assert response.status_code == 200
     latest_debts: Iterable[Debt] = response.context["latest_debts"]
 

--- a/iou/tests/test_routing.py
+++ b/iou/tests/test_routing.py
@@ -1,0 +1,12 @@
+import pytest
+from django.test import Client
+from django.urls import reverse
+
+
+@pytest.mark.django_db
+def test_redirect_home(
+    client: Client,
+):
+    response = client.get("/")
+    assert response.status_code == 301
+    assert response.url == reverse("iou:index")

--- a/iou/urls.py
+++ b/iou/urls.py
@@ -3,6 +3,8 @@ from django.urls import path
 
 from . import views
 
+app_name = "iou"
+
 urlpatterns = [
     # ex: /iou/
     path("", views.index, name="index"),

--- a/iouproject/settings.py
+++ b/iouproject/settings.py
@@ -160,3 +160,15 @@ STORAGES = {
 # https://docs.djangoproject.com/en/dev/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Configuration for Django running behind a reverse proxy.
+# Assumptions for this config:
+# The reverse-proxy must accept client requests only over https.
+# The reverse-proxy sets X-Forwarded-Proto to https.
+# The clients specify the prefix defined in PROXY_PREFIX in the location paths.
+if "PROXY_PREFIX" in environ:
+    PROXY_PREFIX = environ["PROXY_PREFIX"]
+    # https://docs.djangoproject.com/en/6.0/ref/settings/#secure-proxy-ssl-header
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+    FORCE_SCRIPT_NAME = PROXY_PREFIX
+    STATIC_URL = f"{FORCE_SCRIPT_NAME}/{STATIC_URL}"

--- a/iouproject/urls.py
+++ b/iouproject/urls.py
@@ -17,8 +17,10 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
+from django.views.generic.base import RedirectView
 
 urlpatterns = [
+    path("", RedirectView.as_view(pattern_name="iou:index", permanent=True)),
     path("iou/", include("iou.urls")),
     path("admin/", admin.site.urls),
 ]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,5 +1,5 @@
 rm -rf reports
 python -m manage collectstatic --noinput
-python -m pytest --cov=iou  --cov-report=xml --cov-report=html --junitxml="reports/junit.xml"
+python -m pytest --cov=iou --cov=iouproject --cov-report=xml --cov-report=html --junitxml="reports/junit.xml"
 mkdir -p reports
 mv coverage.xml htmlcov reports/.


### PR DESCRIPTION
* Configure urls with a namespace.
* Redirect the root path to the index page.
* Add an optional `PROXY_PREFIX` environment variable to configure the application being run behind a reverse proxy.
* Adjust code coverage config.